### PR TITLE
chore: Improve SSR support by changing globalObject to "this"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,13 @@ module.exports = {
   entry: './src/index.js',
   mode: isProduction ? 'production' : 'development',
   output: {
+    // Improve SSR support by using "this" instead of "self" on the global
+    // object. By default webpack will fallback window calls to "self", which
+    // do not exist in node, by replacing this with "this" we can safely import
+    // the lib in a node environment
+    //
+    // Reference: https://webpack.js.org/configuration/output/#outputglobalobject
+    globalObject: 'this',
     path: path.resolve(__dirname, 'dist'),
     filename: isProduction ? 'player.min.js' : 'player.js',
     library: {


### PR DESCRIPTION
The library could otherwise break when being imported from a SSR environment (like being imported in the SSR side of a Next.js project)